### PR TITLE
Add support for total pending tickets

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,9 @@ The metrics exposed by this plugin are:
 Total active:
 - `helpscout active tickets` - the total number of active tickets in teh mailboxes
 
+Total pending:
+- `helpscout pending tickets` - the total number of pending tickets in teh mailboxes
+
 Weekly:
 - `helpscout tickets modified avg` - the trailing average of tickets modified in the last 7 days
 - `helpscout tickets modified last week` - tickets modified in the last 7 days

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function plugin (apiKey, mailboxes) {
       mailboxes.forEach(function (c) { convos = convos.concat(c); });
 
       totalActive(metrics, convos);
+      totalPending(metrics, convos);
       weekly(metrics, convos);
       oldestBreakdown(metrics, convos);
       todayBreakdown(metrics, convos);
@@ -53,6 +54,18 @@ function plugin (apiKey, mailboxes) {
 function totalActive (metrics, convos) {
   var active = convos.filter(function (convo) { return convo.status === 'active'; });
   metrics.set('helpscout active tickets', active.length);
+}
+
+/**
+ * Calculate the total pending tickets.
+ *
+ * @param {Array|Conversation} convos
+ * @param {Object} results
+ */
+
+function totalPending (metrics, convos) {
+  var pending = convos.filter(function (convo) { return convo.status === 'pending'; });
+  metrics.set('helpscout pending tickets', pending.length);
 }
 
 /**


### PR DESCRIPTION
This adds the total pending tickets count, just like the total active tickets count.

Total pending:
- `helpscout pending tickets` - the total number of pending tickets in teh mailboxes
